### PR TITLE
Add 'Copy Changes' feature to PR files view

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "tasks": {
+    "test": "npm ci && npm run test",
+    "build": "npm install && npm run build",
+    "launch": "npm start"
+  }
+}

--- a/source/feature-manager.tsx
+++ b/source/feature-manager.tsx
@@ -24,6 +24,7 @@ import {
 	_,
 } from './helpers/hotfix.js';
 import asyncForEach from './helpers/async-for-each.js';
+import './features/copy-changes.js';
 
 type CallerFunction = (callback: VoidFunction, signal: AbortSignal) => void | Promise<void> | Deinit;
 type FeatureInitResult = void | false;

--- a/source/features/copy-changes.tsx
+++ b/source/features/copy-changes.tsx
@@ -1,0 +1,168 @@
+import React from 'dom-chef';
+import delegate, {DelegateEvent} from 'delegate-it';
+import * as pageDetect from 'github-url-detection';
+import {stringToBase64} from 'uint8array-extras';
+
+import features from '../feature-manager.js';
+import api from '../github-helpers/api.js';
+import showToast from '../github-helpers/toast.js';
+import {getBranches} from '../github-helpers/pr-branches.js';
+import getPrInfo from '../github-helpers/get-pr-info.js';
+import observe from '../helpers/selector-observer.js';
+
+async function getMergeBaseReference(): Promise<string> {
+	const {base, head} = getBranches();
+	const response = await api.v3(`compare/${base.relative}...${head.relative}`);
+	return response.merge_base_commit.sha;
+}
+
+async function getHeadReference(): Promise<string> {
+	const {base} = getBranches();
+	const {headRefOid} = await getPrInfo(base.relative);
+	return headRefOid;
+}
+
+async function getFile(filePath: string): Promise<string | undefined> {
+	const ref = await getMergeBaseReference();
+	const {textContent} = await api.v3(
+		`contents/${filePath}?ref=${ref}`,
+		{
+			json: false,
+			headers: {
+				Accept: 'application/vnd.github.raw',
+			},
+		},
+	);
+	return textContent;
+}
+
+async function copyChanges(progress: (message: string) => void, originalFileName: string, newFileName: string): Promise<void> {
+	const [headReference, file] = await Promise.all([
+		getHeadReference(),
+		getFile(originalFileName),
+	]);
+
+	const isNewFile = !file;
+	const isRenamed = originalFileName !== newFileName;
+
+	const contents = file ? stringToBase64(file) : '';
+	const deleteNewFile = {deletions: [{path: newFileName}]};
+	const restoreOldFile = {additions: [{path: originalFileName, contents}]};
+	const fileChanges = isRenamed
+		? {...restoreOldFile, ...deleteNewFile}
+		: isNewFile
+			? deleteNewFile
+			: restoreOldFile;
+
+	const {nameWithOwner, branch: prBranch} = getBranches().head;
+	progress('Creating new branch…');
+
+	const newBranchName = `${prBranch}-copy-${Date.now()}`;
+	await api.v4(`
+		mutation createBranch ($input: CreateRefInput!) {
+			createRef(input: $input) {
+				ref {
+					name
+				}
+			}
+		}
+	`, {
+		variables: {
+			input: {
+				repositoryNameWithOwner: nameWithOwner,
+				name: `refs/heads/${newBranchName}`,
+				oid: headReference,
+			},
+		},
+	});
+
+	progress('Committing changes…');
+	await api.v4(`
+		mutation commitChanges ($input: CreateCommitOnBranchInput!) {
+			createCommitOnBranch(input: $input) {
+				commit {
+					oid
+				}
+			}
+		}
+	`, {
+		variables: {
+			input: {
+				branch: {
+					repositoryNameWithOwner: nameWithOwner,
+					branchName: newBranchName,
+				},
+				expectedHeadOid: headReference,
+				fileChanges,
+				message: {
+					headline: `Copy changes to ${originalFileName}`,
+				},
+			},
+		},
+	});
+
+	progress('Creating pull request…');
+	await api.v4(`
+		mutation createPullRequest ($input: CreatePullRequestInput!) {
+			createPullRequest(input: $input) {
+				pullRequest {
+					url
+				}
+			}
+		}
+	`, {
+		variables: {
+			input: {
+				repositoryNameWithOwner: nameWithOwner,
+				baseRefName: prBranch,
+				headRefName: newBranchName,
+				title: `Copy changes to ${originalFileName}`,
+			},
+		},
+	});
+}
+
+async function handleClick(event: DelegateEvent<MouseEvent, HTMLButtonElement>): Promise<void> {
+	const menuItem = event.delegateTarget;
+
+	try {
+		const [originalFileName, newFileName = originalFileName] = menuItem
+			.closest('[data-path]')!
+			.querySelector('.Link--primary')!
+			.textContent
+			.split(' → ');
+		await showToast(async progress => copyChanges(progress!, originalFileName, newFileName), {
+			message: 'Loading info…',
+			doneMessage: 'Changes copied',
+		});
+
+		menuItem.closest('.file')!.remove();
+	} catch (error) {
+		features.log.error(import.meta.url, error);
+	}
+}
+
+function add(editFile: HTMLAnchorElement): void {
+	editFile.after(
+		<button
+			className="pl-5 dropdown-item btn-link rgh-copy-changes"
+			role="menuitem"
+			type="button"
+		>
+			Copy changes
+		</button>,
+	);
+}
+
+function init(signal: AbortSignal): void {
+	observe('.js-file-header-dropdown a[aria-label^="Change this"]', add, {signal});
+
+	delegate('.rgh-copy-changes', 'click', handleClick, {capture: true, signal});
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.isPRFiles,
+	],
+	init,
+});


### PR DESCRIPTION
Fixes #4

Add a new 'Copy Changes' feature to create a new branch, commit changes, and create a new PR from a file in the current PR.

* **source/features/copy-changes.tsx**: 
  - Implement the 'Copy Changes' feature.
  - Add a new option to the context menu with the label 'Copy Changes'.
  - Implement the functionality to create a new branch, commit changes, and create a new PR.
* **source/feature-manager.tsx**: 
  - Import the new 'Copy Changes' feature.
  - Add the new feature to the list of features to be initialized.
* **.devcontainer.json**: 
  - Add a devcontainer configuration file with tasks for testing, building, and launching the project.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dciborow/refined-github/issues/4?shareId=4a463cff-5ed2-40d8-9fc2-57d9ef403212).

## Summary by Sourcery

Add a 'Copy Changes' feature to the PR files view, enabling users to create a new branch, commit changes, and open a new PR from a file in the current PR. Update the feature manager to include this new feature and introduce a devcontainer configuration for development tasks.

New Features:
- Introduce a 'Copy Changes' feature that allows users to create a new branch, commit changes, and create a new pull request from a file in the current PR.

Enhancements:
- Add the 'Copy Changes' feature to the list of features initialized in the feature manager.

Build:
- Add a devcontainer configuration file with tasks for testing, building, and launching the project.